### PR TITLE
fix: move logger declaration inside Execute

### DIFF
--- a/pkg/commands/example/example.go
+++ b/pkg/commands/example/example.go
@@ -7,9 +7,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var logger = zap.L()
-
 func Execute(c *cli.Context) error {
+	var logger = zap.L()
 	logger.Info("example called")
 	return nil
 }


### PR DESCRIPTION
fix: move logger declaration inside Execute